### PR TITLE
ci: add Tricorder build step to deployment workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -39,6 +39,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           pnpm-version: ${{ env.PNPM_VERSION }}
 
+      - name: Build Tricorder
+        run: pnpm run build:tricorder
+
       - name: Type check API
         run: pnpm run type-check:api
 


### PR DESCRIPTION
## Summary
Fixes deployment failures caused by missing Tricorder build step in the deployment workflow.

## Problem
The latest deployment failed with TypeScript errors:
```
Cannot find module '@tuvixrss/tricorder' or its corresponding type declarations.
```

## Root Cause
- PR #29 added the Tricorder package and updated `ci-reusable.yml` to build Tricorder before type-checking dependent packages
- All CI checks passed because the workflow had the necessary build step
- However, `deploy-cloudflare.yml` was not updated with this build step
- When deployment ran, it tried to type-check the API without building Tricorder first, causing module not found errors

## Changes
- Added "Build Tricorder" step to `deploy-cloudflare.yml` before the API type-check step
- This matches the pattern used in `ci-reusable.yml`

## Testing
Tricorder has comprehensive CI coverage via `ci-tricorder.yml`:
- Runs on PR when Tricorder files change
- Runs on push to main/development when Tricorder files change  
- Includes: lint, format check, type-check, tests with coverage, and build verification

## Verification
Tested locally:
```bash
pnpm run build:tricorder && pnpm run type-check:api
```
All type checks pass successfully.

Fixes the deployment failure reported in the workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)