### PR TITLE
ci: fix notify job wrangler.toml missing error

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -261,6 +261,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Create wrangler.toml from example
+        uses: ./.github/actions/substitute-d1-database-id
+        with:
+          d1-database-id: ${{ secrets.D1_DATABASE_ID }}
+
       - name: Get worker name
         id: worker-name
         uses: ./.github/actions/get-worker-name


### PR DESCRIPTION
## Summary
Fixes the notify job failure in the deployment workflow caused by missing `wrangler.toml` file.

## Problem
The notify job was failing with:
```
grep: packages/api/wrangler.toml: No such file or directory
Error: Process completed with exit code 2.
```

## Root Cause
Each GitHub Actions job runs in a fresh environment. The `deploy-api` job creates `wrangler.toml` from the example file, but this file is not available to the `notify` job. The `notify` job was trying to read the worker name directly after checkout, before creating the file.

## Solution
Added the "Create wrangler.toml from example" step to the notify job before attempting to get the worker name. This matches the pattern used in the `deploy-api` job:

1. Checkout code
2. **Create wrangler.toml from example** (NEW)
3. Get worker name from wrangler.toml
4. Generate deployment summary

## Changes
- Added `substitute-d1-database-id` action call to notify job
- This creates the `wrangler.toml` file before `get-worker-name` tries to read it

## Testing
The workflow structure now matches the successful pattern in the deploy-api job where wrangler.toml is created before being read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)