### PR TITLE
fix: correct enctype casing in PWA manifest

### DIFF
--- a/packages/app/public/manifest.webmanifest
+++ b/packages/app/public/manifest.webmanifest
@@ -174,7 +174,7 @@
   "share_target": {
     "action": "/app/subscriptions",
     "method": "GET",
-    "encType": "application/x-www-form-urlencoded",
+    "enctype": "application/x-www-form-urlencoded",
     "params": {
       "url": "subscribe"
     }


### PR DESCRIPTION
## Summary
Fixes the manifest validation warning about enctype defaulting by correcting the property name casing.

## Problem
The manifest was showing a warning:
> Manifest: Enctype should be set to either application/x-www-form-urlencoded or multipart/form-data. It currently defaults to application/x-www-form-urlencoded

## Root Cause
The Web App Manifest specification requires **lowercase** `enctype`, but we were using camelCase `encType`. This caused validators to not recognize the property, making it appear as if enctype was missing and defaulting.

## Solution
Changed `encType` to `enctype` (lowercase) in the `share_target` configuration to match the W3C Web App Manifest specification.

**Before:**
```json
"share_target": {
  "action": "/app/subscriptions",
  "method": "GET",
  "encType": "application/x-www-form-urlencoded",  // ❌ Wrong casing
  "params": {
    "url": "subscribe"
  }
}
```

**After:**
```json
"share_target": {
  "action": "/app/subscriptions",
  "method": "GET",
  "enctype": "application/x-www-form-urlencoded",  // ✅ Correct casing
  "params": {
    "url": "subscribe"
  }
}
```

## Technical Details
- The value `application/x-www-form-urlencoded` is correct for GET method with URL parameters
- This is the appropriate encoding for sharing URLs to the app
- Now properly recognized by PWA manifest validators

## Reference
[W3C Web Share Target Specification](https://w3c.github.io/web-share-target/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)