### PR TITLE
fix(ci): skip deployment for npm package releases

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -18,10 +18,35 @@ env:
   PNPM_VERSION: 10.19.0
   NODE_VERSION: '20'
 
+# Only run for app releases (v*), not package releases (@tuvixrss/*)
+# Package releases like @tuvixrss/tricorder@x.y.z should not trigger deployment
 jobs:
+  check-release-type:
+    name: Check if this is an app release
+    runs-on: ubuntu-latest
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+    steps:
+      - name: Check release tag format
+        id: check
+        run: |
+          TAG="${{ github.event.release.tag_name || github.event.inputs.version }}"
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "should-deploy=true" >> $GITHUB_OUTPUT
+            echo "✅ App release detected: $TAG"
+          elif [[ "$TAG" =~ ^@tuvixrss/ ]]; then
+            echo "should-deploy=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Package release detected: $TAG - skipping deployment"
+          else
+            echo "should-deploy=true" >> $GITHUB_OUTPUT
+            echo "⚠️  Unknown tag format: $TAG - proceeding with deployment"
+          fi
+
   deploy-api:
     name: Deploy API to Cloudflare Workers
     runs-on: ubuntu-latest
+    needs: [check-release-type]
+    if: needs.check-release-type.outputs.should-deploy == 'true'
     environment:
       name: production
     env:
@@ -149,7 +174,8 @@ jobs:
   deploy-app:
     name: Deploy App to Cloudflare Pages
     runs-on: ubuntu-latest
-    needs: [deploy-api]
+    needs: [check-release-type, deploy-api]
+    if: needs.check-release-type.outputs.should-deploy == 'true'
     environment:
       name: production
     steps:
@@ -253,8 +279,8 @@ jobs:
   notify:
     name: Notify Deployment Status
     runs-on: ubuntu-latest
-    needs: [deploy-api, deploy-app]
-    if: always()
+    needs: [check-release-type, deploy-api, deploy-app]
+    if: always() && needs.check-release-type.outputs.should-deploy == 'true'
     environment:
       name: production
     steps:


### PR DESCRIPTION
This pull request updates the Cloudflare deployment workflow to ensure deployments only occur for app releases (tags starting with `v*`), and not for package releases (tags like `@tuvixrss/*`). The workflow now checks the release tag format before proceeding with deployment jobs, preventing unnecessary deployments for package releases.

Release type check and conditional deployment:

* Added a new `check-release-type` job to determine if the workflow should deploy, based on the release tag format. Only tags matching `v*` will trigger deployment; package releases will be skipped. (`.github/workflows/deploy-cloudflare.yml`)

Deployment job dependencies and conditions:

* Updated `deploy-api` and `deploy-app` jobs to depend on `check-release-type` and only run if an app release is detected (`should-deploy == 'true'`). (`.github/workflows/deploy-cloudflare.yml`)
* Modified the `notify` job to depend on `check-release-type`, `deploy-api`, and `deploy-app`, and to only notify if an app release is being deployed. (`.github/workflows/deploy-cloudflare.yml`)