### PR TITLE
fix(ci): trigger npm publish on GitHub release creation

### DIFF
--- a/.github/workflows/publish-tricorder.yml
+++ b/.github/workflows/publish-tricorder.yml
@@ -7,6 +7,10 @@ on:
       - 'tricorder-v*.*.*'
       - '@tuvixrss/tricorder@*.*.*'
 
+  # Trigger on GitHub releases for tricorder package
+  release:
+    types: [published]
+
   # Manual trigger with version input
   workflow_dispatch:
     inputs:
@@ -29,10 +33,34 @@ permissions:
   contents: read   # Required to read repository contents
 
 jobs:
+  # Check if this release is for tricorder package
+  check-package:
+    name: Check if tricorder package release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    outputs:
+      should-publish: ${{ steps.check.outputs.should-publish }}
+    steps:
+      - name: Check release tag format
+        id: check
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          if [[ "$TAG" =~ ^(tricorder-v|@tuvixrss/tricorder@) ]]; then
+            echo "should-publish=true" >> $GITHUB_OUTPUT
+            echo "✅ Tricorder package release detected: $TAG"
+          else
+            echo "should-publish=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Not a tricorder release: $TAG - skipping publish"
+          fi
+
   # Verify tricorder package independently
   verify:
     name: Verify Tricorder Package
     runs-on: ubuntu-latest
+    needs: [check-package]
+    if: |
+      always() &&
+      (needs.check-package.result == 'skipped' || needs.check-package.outputs.should-publish == 'true')
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
The publish workflow now triggers on both:
1. Tag pushes (original behavior)
2. GitHub Release publication (new)

Added check-package job to filter releases:
- Only runs for tricorder package releases (@tuvixrss/tricorder@* or tricorder-v*)
- Skips for app releases (v*)
- Verify and publish jobs depend on this check

This allows creating releases through GitHub UI which automatically publishes to npm via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a clear description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI update
- [ ] Other (please describe):

## Related Issues

<!-- Link any related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests pass (`pnpm test`)
- [ ] Type checking passes (`pnpm type-check`)
- [ ] Linting passes (`pnpm lint`)

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Documentation

- [ ] Documentation has been updated (if needed)
- [ ] Code comments added for complex logic
- [ ] README updated (if needed)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional Notes

<!-- Any additional information that reviewers should know -->
