### PR TITLE
fix(tricorder): correct repository URL for provenance verification

### DIFF
--- a/packages/tricorder/package.json
+++ b/packages/tricorder/package.json
@@ -44,13 +44,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TechSquidTV/TuvixRSS.git",
+    "url": "https://github.com/TechSquidTV/Tuvix-RSS.git",
     "directory": "packages/tricorder"
   },
   "bugs": {
-    "url": "https://github.com/TechSquidTV/TuvixRSS/issues"
+    "url": "https://github.com/TechSquidTV/Tuvix-RSS/issues"
   },
-  "homepage": "https://github.com/TechSquidTV/TuvixRSS/tree/main/packages/tricorder#readme",
+  "homepage": "https://github.com/TechSquidTV/Tuvix-RSS/tree/main/packages/tricorder#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
This pull request updates the repository URLs in the `packages/tricorder/package.json` file to reflect a change from `TuvixRSS` to `Tuvix-RSS`. This ensures that all links point to the correct repository location. 

* Updated the `repository.url`, `bugs.url`, and `homepage` fields in `package.json` to use the new repository name `Tuvix-RSS` instead of `TuvixRSS`.