### PR TITLE
docs: add browser extension section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Head over to **[tuvix.app](https://tuvix.app)** to create your free account and 
 
 Immediately begin subscribing to your favorite feeds. Remember, you can always export your data to OPML and migrate to your own self-hosted instance, or any other RSS reader.
 
+### Browser Extension
+
+Install the **[Tuvix Tricorder Extension](https://github.com/TechSquidTV/Tuvix-Tricorder-Extension)** for Chrome and Firefox to easily discover and subscribe to RSS feeds on any website with one click.
+
 ---
 
 ## 🚀 Deployment


### PR DESCRIPTION
## Summary

Adds a Browser Extension subsection under the Hosted section to promote the Tuvix Tricorder Extension for Chrome and Firefox.

## Changes

- Added Browser Extension subsection with link to the extension repository
- Positioned it prominently in the Hosted section for better discoverability

## Motivation

Users should be aware of the companion browser extension that makes it easy to discover and subscribe to RSS feeds on any website with one click.

Extension repository: https://github.com/TechSquidTV/Tuvix-Tricorder-Extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)