### PR TITLE
Fix: deployment

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           RELEASE_VERSION="${{ steps.release-version.outputs.version }}"
           cd packages/api
-          echo "$RELEASE_VERSION" | npx wrangler secret put SENTRY_RELEASE --name "${{ steps.worker-name.outputs.name }}"
+          echo "$RELEASE_VERSION" | pnpm exec wrangler secret put SENTRY_RELEASE --name "${{ steps.worker-name.outputs.name }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -110,7 +110,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
           command: deploy
-          wranglerVersion: "3"
+          packageManager: pnpm
 
       - name: Output API deployment URL
         if: success()
@@ -160,7 +160,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
           command: d1 migrations apply tuvix --remote
-          wranglerVersion: "3"
+          packageManager: pnpm
         env:
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
 
@@ -266,7 +266,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy packages/app/dist --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }} --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: "3"
+          packageManager: pnpm
 
       - name: Output App deployment URL
         if: success()

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           DEPLOYMENT_VERSION="${{ steps.deployment-version.outputs.version }}"
           cd packages/api
-          echo "$DEPLOYMENT_VERSION" | npx wrangler secret put SENTRY_RELEASE --name "${{ steps.worker-name.outputs.name }}"
+          echo "$DEPLOYMENT_VERSION" | pnpm exec wrangler secret put SENTRY_RELEASE --name "${{ steps.worker-name.outputs.name }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -94,7 +94,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/api
           command: deploy
-          wranglerVersion: "3"
+          packageManager: pnpm
         env:
           WRANGLER_SEND_METRICS: "false"
 
@@ -214,7 +214,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy packages/app/dist --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          wranglerVersion: "3"
+          packageManager: pnpm
 
       - name: Output App deployment URL
         if: success()


### PR DESCRIPTION
This pull request updates the Cloudflare deployment workflows to use `pnpm` as the package manager instead of relying on `npx` or specifying the `wranglerVersion`. The changes affect both production (`deploy-cloudflare.yml`) and development (`deploy-dev.yml`) workflows and ensure consistency in how commands are executed and secrets are set.

**Switch to pnpm for deployment and secret management:**

* Changed the command for setting the `SENTRY_RELEASE` secret from `npx wrangler` to `pnpm exec wrangler` in both `.github/workflows/deploy-cloudflare.yml` and `.github/workflows/deploy-dev.yml`. [[1]](diffhunk://#diff-7a96ba89bca759f6a3712e3c3c9aeffde878af6a82c6246c247264a3dd9d5b93L100-R100) [[2]](diffhunk://#diff-6437260bac3153131c87371ba3b15180e0e07bb9a3e0ee6f7c25068aa9bdccdfL84-R84)

**Update workflow configuration to use pnpm as the package manager:**

* Replaced the `wranglerVersion: "3"` configuration with `packageManager: pnpm` for all relevant deployment and migration steps in `.github/workflows/deploy-cloudflare.yml`. [[1]](diffhunk://#diff-7a96ba89bca759f6a3712e3c3c9aeffde878af6a82c6246c247264a3dd9d5b93L113-R113) [[2]](diffhunk://#diff-7a96ba89bca759f6a3712e3c3c9aeffde878af6a82c6246c247264a3dd9d5b93L163-R163) [[3]](diffhunk://#diff-7a96ba89bca759f6a3712e3c3c9aeffde878af6a82c6246c247264a3dd9d5b93L269-R269)
* Replaced the `wranglerVersion: "3"` configuration with `packageManager: pnpm` for deployment steps in `.github/workflows/deploy-dev.yml`. [[1]](diffhunk://#diff-6437260bac3153131c87371ba3b15180e0e07bb9a3e0ee6f7c25068aa9bdccdfL97-R97) [[2]](diffhunk://#diff-6437260bac3153131c87371ba3b15180e0e07bb9a3e0ee6f7c25068aa9bdccdfL217-R217)