### PR TITLE
fix(api): complete batch query undefined input handling

### DIFF
--- a/packages/api/src/routers/__tests__/batch-query-undefined-input.test.ts
+++ b/packages/api/src/routers/__tests__/batch-query-undefined-input.test.ts
@@ -60,7 +60,8 @@ describe("Batch Query Input Handling (TUVIX-API-14)", () => {
 
     // Simulate what happens when tRPC sends a batch GET request
     // where the input is undefined (empty object in query string)
-    const result = await caller.subscriptions.list(undefined as any);
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.subscriptions.list(undefined);
 
     expect(result).toBeDefined();
     expect(result.items).toBeInstanceOf(Array);
@@ -72,7 +73,8 @@ describe("Batch Query Input Handling (TUVIX-API-14)", () => {
     const caller = createCaller();
 
     // Simulate undefined input from batch GET request
-    const result = await caller.articles.getCounts(undefined as any);
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.articles.getCounts(undefined);
 
     expect(result).toBeDefined();
     expect(typeof result.all).toBe("number");
@@ -85,7 +87,8 @@ describe("Batch Query Input Handling (TUVIX-API-14)", () => {
     const caller = createCaller();
 
     // Simulate undefined input from batch GET request
-    const result = await caller.articles.list(undefined as any);
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.articles.list(undefined);
 
     expect(result).toBeDefined();
     expect(result.items).toBeInstanceOf(Array);
@@ -93,19 +96,85 @@ describe("Batch Query Input Handling (TUVIX-API-14)", () => {
     expect(typeof result.hasMore).toBe("boolean");
   });
 
+  it("should handle undefined input in categories.list", async () => {
+    const caller = createCaller();
+
+    // Simulate undefined input from batch GET request
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.categories.list(undefined);
+
+    expect(result).toBeDefined();
+    expect(result).toBeInstanceOf(Array);
+  });
+
+  it("should handle undefined input in userSettings.get", async () => {
+    const caller = createCaller();
+
+    // Simulate undefined input from batch GET request
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.userSettings.get(undefined);
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("theme");
+    expect(result).toHaveProperty("autoAgeDays");
+  });
+
+  it("should handle undefined input in plans.list", async () => {
+    const caller = createCaller();
+
+    // Simulate undefined input from batch GET request
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.plans.list(undefined);
+
+    expect(result).toBeDefined();
+    expect(result).toBeInstanceOf(Array);
+  });
+
+  it("should handle undefined input in admin.getGlobalSettings", async () => {
+    // Make the test user an admin
+    await db
+      .update(schema.user)
+      .set({ role: "admin" })
+      .where(eq(schema.user.id, testUser.id));
+
+    // Create caller with admin role
+    const adminCaller = appRouter.createCaller({
+      db,
+      user: { userId: testUser.id, username: "testuser", role: "admin" },
+      env: {} as any,
+      headers: {},
+      req: {} as any,
+      cache: {},
+    });
+
+    // Simulate undefined input in admin.getGlobalSettings
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await adminCaller.admin.getGlobalSettings(undefined);
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("maxLoginAttempts");
+    expect(result).toHaveProperty("allowRegistration");
+  });
+
   it("should handle batch request with mixed undefined and defined inputs", async () => {
     const caller = createCaller();
 
     // Simulate batch request where some procedures get undefined input
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const listResultPromise = caller.subscriptions.list(undefined);
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const countsResultPromise = caller.articles.getCounts(undefined);
+    const detailedListResultPromise = caller.articles.list({
+      // defined input with filters
+      limit: 10,
+      offset: 0,
+      read: false,
+    });
+
     const [listResult, countsResult, detailedListResult] = await Promise.all([
-      caller.subscriptions.list(undefined as any), // undefined input
-      caller.articles.getCounts(undefined as any), // undefined input
-      caller.articles.list({
-        // defined input with filters
-        limit: 10,
-        offset: 0,
-        read: false,
-      }),
+      listResultPromise,
+      countsResultPromise,
+      detailedListResultPromise,
     ]);
 
     // All should succeed without validation errors
@@ -118,7 +187,8 @@ describe("Batch Query Input Handling (TUVIX-API-14)", () => {
     const caller = createCaller();
 
     // When input is undefined, defaults should be applied
-    const result = await caller.subscriptions.list(undefined as any);
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await caller.subscriptions.list(undefined);
 
     // The withUndefinedAsEmpty helper converts undefined -> {}
     // Then paginationInputSchema applies defaults: limit=50, offset=0
@@ -160,7 +230,8 @@ describe("Batch Query Input Handling (TUVIX-API-14)", () => {
     });
 
     // Simulate undefined input in admin.listUsers
-    const result = await adminCaller.admin.listUsers(undefined as any);
+    // @ts-expect-error - Testing runtime behavior when tRPC passes undefined
+    const result = await adminCaller.admin.listUsers(undefined);
 
     expect(result).toBeDefined();
     expect(result.items).toBeInstanceOf(Array);

--- a/packages/api/src/routers/admin.ts
+++ b/packages/api/src/routers/admin.ts
@@ -28,9 +28,9 @@ import {
 } from "@/services/limits";
 import {
   createPaginatedSchema,
+  withUndefinedAsEmpty,
   paginationInputSchema,
   createPaginatedResponse,
-  withUndefinedAsEmpty,
 } from "@/types/pagination";
 import { validatePlanExists, getAllPlans } from "@/services/plans";
 import {
@@ -743,6 +743,7 @@ export const adminRouter = router({
    * Get global settings
    */
   getGlobalSettings: adminProcedure
+    .input(withUndefinedAsEmpty(z.object({})))
     .output(globalSettingsOutputSchema)
     .query(async ({ ctx }) => {
       const [settings] = await ctx.db

--- a/packages/api/src/routers/categories.ts
+++ b/packages/api/src/routers/categories.ts
@@ -18,12 +18,14 @@ import {
   incrementCategoryCount,
   decrementCategoryCount,
 } from "@/services/limits";
+import { withUndefinedAsEmpty } from "@/types/pagination";
 
 export const categoriesRouter = router({
   /**
    * List all user's categories
    */
   list: rateLimitedProcedure
+    .input(withUndefinedAsEmpty(z.object({})))
     .output(z.array(selectCategorySchema))
     .query(async ({ ctx }) => {
       const { userId } = ctx.user;

--- a/packages/api/src/routers/plans.ts
+++ b/packages/api/src/routers/plans.ts
@@ -11,6 +11,7 @@ import { eq } from "drizzle-orm";
 import { router, publicProcedure, adminProcedure } from "@/trpc/init";
 import { getAllPlans, getPlanById } from "@/services/plans";
 import * as schema from "@/db/schema";
+import { withUndefinedAsEmpty } from "@/types/pagination";
 
 export const plansRouter = router({
   /**
@@ -18,6 +19,7 @@ export const plansRouter = router({
    * Public endpoint - no authentication required
    */
   list: publicProcedure
+    .input(withUndefinedAsEmpty(z.object({})))
     .output(
       z.array(
         z.object({

--- a/packages/api/src/routers/userSettings.ts
+++ b/packages/api/src/routers/userSettings.ts
@@ -14,6 +14,7 @@ import {
 } from "@/db/schemas.zod";
 import { getUserUsage, getUserLimits } from "@/services/limits";
 import type { Database } from "@/db/client";
+import { withUndefinedAsEmpty } from "@/types/pagination";
 
 // ============================================================================
 // HELPERS
@@ -89,6 +90,7 @@ export const userSettingsRouter = router({
    * Get user's settings (creates defaults if not exists)
    */
   get: rateLimitedProcedure
+    .input(withUndefinedAsEmpty(z.object({})))
     .output(selectUserSettingsSchema)
     .query(async ({ ctx }) => {
       const { userId } = ctx.user;


### PR DESCRIPTION
This pull request improves how the API handles cases where tRPC batch queries provide `undefined` as input, ensuring that all relevant endpoints gracefully apply default values instead of failing validation. The changes include both new tests and updates to router input schemas to automatically convert `undefined` inputs into empty objects, which allows for defaulting and prevents runtime errors.

The most important changes are:

**Test Coverage Enhancements:**

* Expanded the test suite in `batch-query-undefined-input.test.ts` to verify that all major endpoints (`categories.list`, `userSettings.get`, `plans.list`, `admin.getGlobalSettings`, and `admin.listUsers`) correctly handle `undefined` input from batch requests, and that mixed defined/undefined batch inputs are processed without validation errors. [[1]](diffhunk://#diff-e051fb3a3ba259c41afd7a7fdd81622db471a0eaebe498397823f78aef145e86L63-R64) [[2]](diffhunk://#diff-e051fb3a3ba259c41afd7a7fdd81622db471a0eaebe498397823f78aef145e86L75-R77) [[3]](diffhunk://#diff-e051fb3a3ba259c41afd7a7fdd81622db471a0eaebe498397823f78aef145e86L88-R177) [[4]](diffhunk://#diff-e051fb3a3ba259c41afd7a7fdd81622db471a0eaebe498397823f78aef145e86L121-R191) [[5]](diffhunk://#diff-e051fb3a3ba259c41afd7a7fdd81622db471a0eaebe498397823f78aef145e86L163-R234)

**Input Schema Improvements:**

* Updated `categoriesRouter.list`, `userSettingsRouter.get`, `plansRouter.list`, and `adminRouter.getGlobalSettings` to use `withUndefinedAsEmpty(z.object({}))` for their `.input()` schemas, ensuring that `undefined` input is treated as an empty object and defaults are applied. [[1]](diffhunk://#diff-ea66d5bef78f9cd903ca481a27870eb150c84d32fb1fbf848b90c5e6701ee0afR21-R28) [[2]](diffhunk://#diff-cf6d33d2ded1dd6a64ca6dc15a28730a4aae44c9d189e3f59889eaa79294521eR17) [[3]](diffhunk://#diff-cf6d33d2ded1dd6a64ca6dc15a28730a4aae44c9d189e3f59889eaa79294521eR93) [[4]](diffhunk://#diff-faa407e09848a3bdc1c0f9d75ec0bc01cef25a8e24b05e4fd073b3f070f994aeR746) [[5]](diffhunk://#diff-d9cebf4d6460581a28ac2a13c72d1688e84635ae3a20c95ccd12080f8bb84f8dR14-R22)

**Code Cleanup:**

* Fixed import ordering for `withUndefinedAsEmpty` in affected routers for consistency and clarity. [[1]](diffhunk://#diff-faa407e09848a3bdc1c0f9d75ec0bc01cef25a8e24b05e4fd073b3f070f994aeR31-L33) [[2]](diffhunk://#diff-ea66d5bef78f9cd903ca481a27870eb150c84d32fb1fbf848b90c5e6701ee0afR21-R28) [[3]](diffhunk://#diff-d9cebf4d6460581a28ac2a13c72d1688e84635ae3a20c95ccd12080f8bb84f8dR14-R22) [[4]](diffhunk://#diff-cf6d33d2ded1dd6a64ca6dc15a28730a4aae44c9d189e3f59889eaa79294521eR17)

These changes make the API more robust to real-world usage patterns, especially when integrating with tRPC batch requests that may omit input parameters.