### PR TITLE
fix: vacuum

### DIFF
--- a/packages/api/scripts/wipe-staging.sql
+++ b/packages/api/scripts/wipe-staging.sql
@@ -87,5 +87,6 @@ DROP TABLE IF EXISTS global_settings;
 DROP TABLE IF EXISTS d1_migrations;
 DROP TABLE IF EXISTS __drizzle_migrations;
 
--- Vacuum to reclaim space
-VACUUM;
+-- Note: VACUUM cannot run inside a transaction (SQLite limitation)
+-- D1/Wrangler wraps SQL file execution in a transaction, so we skip VACUUM here.
+-- Space will be reclaimed automatically by SQLite over time.


### PR DESCRIPTION
This pull request updates the database wipe script to address SQLite's handling of the VACUUM command. The script now includes comments explaining why the VACUUM command is omitted, clarifying that SQLite will reclaim space automatically over time.

- Database maintenance clarification:
  * Removed the `VACUUM;` command from `wipe-staging.sql` and added comments explaining that VACUUM cannot run inside a transaction due to SQLite limitations, and that space will be reclaimed automatically.