### PR TITLE
Fix/distributed tracing

### DIFF
--- a/packages/api/src/hono/app.ts
+++ b/packages/api/src/hono/app.ts
@@ -55,30 +55,26 @@ export function createHonoApp(config: HonoAppConfig) {
     const baggage = c.req.header("baggage");
 
     // Continue trace from frontend (or start new trace if no headers)
-    return await Sentry.continueTrace(
-      { sentryTrace, baggage },
-      async () => {
-        // Create HTTP server span within the continued trace
-        return await Sentry.startSpan(
-          {
-            name: `${c.req.method} ${c.req.path}`,
-            op: "http.server",
-            attributes: {
-              "http.method": c.req.method,
-              "http.route": c.req.path,
-              "http.url": c.req.url,
-            },
+    return await Sentry.continueTrace({ sentryTrace, baggage }, async () => {
+      // Create HTTP server span within the continued trace
+      return await Sentry.startSpan(
+        {
+          name: `${c.req.method} ${c.req.path}`,
+          op: "http.server",
+          attributes: {
+            "http.method": c.req.method,
+            "http.route": c.req.path,
+            "http.url": c.req.url,
           },
-          async (span) => {
-            await next();
-            // Add response status after request completes
-            span.setAttribute("http.status_code", c.res.status);
-          }
-        );
-      }
-    );
+        },
+        async (span) => {
+          await next();
+          // Add response status after request completes
+          span.setAttribute("http.status_code", c.res.status);
+        }
+      );
+    });
   });
-
 
   // CORS middleware (must be before routes)
   const corsOrigins = getCorsOrigins(config.env);

--- a/packages/api/src/hono/app.ts
+++ b/packages/api/src/hono/app.ts
@@ -38,8 +38,9 @@ export function createHonoApp(config: HonoAppConfig) {
     await next();
   });
 
-  // Sentry HTTP tracing middleware
-  // Creates spans for all HTTP requests with proper transaction names
+  // Distributed tracing middleware
+  // Manually extracts sentry-trace and baggage headers to continue traces from frontend
+  // Required per https://docs.sentry.io/platforms/javascript/guides/cloudflare/tracing/distributed-tracing/custom-instrumentation
   app.use("*", async (c, next) => {
     const Sentry = c.get("sentry");
     const env = c.get("env");
@@ -49,29 +50,35 @@ export function createHonoApp(config: HonoAppConfig) {
       return await next();
     }
 
-    // Create transaction name from method and path
-    const method = c.req.method;
-    const path = c.req.path;
+    // Extract distributed tracing headers sent by frontend
+    const sentryTrace = c.req.header("sentry-trace");
+    const baggage = c.req.header("baggage");
 
-    // Use Sentry.startSpan to create a trace for this HTTP request
-    return await Sentry.startSpan(
-      {
-        name: `${method} ${path}`,
-        op: "http.server",
-        attributes: {
-          "http.method": method,
-          "http.route": path,
-          "http.url": c.req.url,
-        },
-      },
-      async (span) => {
-        await next();
-
-        // Add response status to span using the provided span parameter
-        span.setAttribute("http.status_code", c.res.status);
+    // Continue trace from frontend (or start new trace if no headers)
+    return await Sentry.continueTrace(
+      { sentryTrace, baggage },
+      async () => {
+        // Create HTTP server span within the continued trace
+        return await Sentry.startSpan(
+          {
+            name: `${c.req.method} ${c.req.path}`,
+            op: "http.server",
+            attributes: {
+              "http.method": c.req.method,
+              "http.route": c.req.path,
+              "http.url": c.req.url,
+            },
+          },
+          async (span) => {
+            await next();
+            // Add response status after request completes
+            span.setAttribute("http.status_code", c.res.status);
+          }
+        );
       }
     );
   });
+
 
   // CORS middleware (must be before routes)
   const corsOrigins = getCorsOrigins(config.env);


### PR DESCRIPTION
This pull request updates the Sentry tracing middleware in the `createHonoApp` function to improve distributed tracing. The main change is to manually extract and propagate tracing headers (`sentry-trace` and `baggage`) from incoming requests, allowing traces to continue seamlessly from the frontend to the backend, as recommended in Sentry's distributed tracing documentation.

Distributed tracing improvements:

* Updated the middleware in `packages/api/src/hono/app.ts` to manually extract `sentry-trace` and `baggage` headers from incoming requests and use `Sentry.continueTrace` to propagate distributed traces from the frontend, ensuring proper trace continuation and instrumentation. [[1]](diffhunk://#diff-bd74d4faec3fa66d8dd79f562e7664a8ab6ab0756d73312c710458a4bf269c6fL41-R43) [[2]](diffhunk://#diff-bd74d4faec3fa66d8dd79f562e7664a8ab6ab0756d73312c710458a4bf269c6fL52-R77)
* Refactored the span creation logic to use the continued trace context and improved attribute assignment for HTTP method, route, URL, and response status.